### PR TITLE
feat: add GitHub provider

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -24,6 +24,7 @@
     "@std/yaml": "jsr:@std/yaml@^1.0.5",
     "commander": "npm:commander@^12.1.0",
     "enquirer": "npm:enquirer@^2.4.1",
+    "octokit": "npm:octokit@^4.0.2",
     "zod": "npm:zod@^3.23.8"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@sallai/ask@*": "2.0.2",
     "jsr:@sallai/iro@^1.0.3": "1.0.4",
     "jsr:@std/assert@^1.0.8": "1.0.8",
+    "jsr:@std/async@^1.0.8": "1.0.9",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/cli@*": "1.0.7",
     "jsr:@std/cli@1.0.7": "1.0.7",
@@ -20,11 +21,13 @@
     "jsr:@std/yaml@^1.0.5": "1.0.5",
     "npm:@linear/sdk@*": "33.0.0_graphql@15.9.0",
     "npm:@linear/sdk@33": "33.0.0_graphql@15.9.0",
+    "npm:@octokit/openapi-types@^22.2.0": "22.2.0",
     "npm:@types/node@*": "22.5.4",
     "npm:commander@^12.1.0": "12.1.0",
     "npm:enquirer@*": "2.4.1",
     "npm:enquirer@2.3.6": "2.3.6",
     "npm:enquirer@^2.4.1": "2.4.1",
+    "npm:octokit@^4.0.2": "4.0.2_@octokit+core@6.1.2",
     "npm:ofcoerce@*": "0.7.0",
     "npm:zod@^3.23.8": "3.23.8"
   },
@@ -44,6 +47,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/async@1.0.9": {
+      "integrity": "c6472fd0623b3f3daae023cdf7ca5535e1b721dfbf376562c0c12b3fb4867f91"
     },
     "@std/bytes@1.0.4": {
       "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
@@ -79,6 +85,7 @@
       "integrity": "6e693cbec94c81a1ad3df668685c7ba8e20742bb10305bc7137faa5cf16d2ec4",
       "dependencies": [
         "jsr:@std/assert",
+        "jsr:@std/async",
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.5",
         "jsr:@std/internal",
@@ -104,6 +111,200 @@
         "isomorphic-unfetch"
       ]
     },
+    "@octokit/app@15.1.1_@octokit+core@6.1.2": {
+      "integrity": "sha512-fk8xrCSPTJGpyBdBNI+DcZ224dm0aApv4vi6X7/zTmANXlegKV2Td+dJ+fd7APPaPN7R+xttUsj2Fm+AFDSfMQ==",
+      "dependencies": [
+        "@octokit/auth-app",
+        "@octokit/auth-unauthenticated",
+        "@octokit/core",
+        "@octokit/oauth-app",
+        "@octokit/plugin-paginate-rest",
+        "@octokit/types",
+        "@octokit/webhooks"
+      ]
+    },
+    "@octokit/auth-app@7.1.3": {
+      "integrity": "sha512-GZdkOp2kZTIy5dG9oXqvzUAZiPvDx4C/lMlN6yQjtG9d/+hYa7W8WXTJoOrXE8UdfL9A/sZMl206dmtkl9lwVQ==",
+      "dependencies": [
+        "@octokit/auth-oauth-app",
+        "@octokit/auth-oauth-user",
+        "@octokit/request",
+        "@octokit/request-error",
+        "@octokit/types",
+        "toad-cache",
+        "universal-github-app-jwt",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/auth-oauth-app@8.1.1": {
+      "integrity": "sha512-5UtmxXAvU2wfcHIPPDWzVSAWXVJzG3NWsxb7zCFplCWEmMCArSZV0UQu5jw5goLQXbFyOr5onzEH37UJB3zQQg==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/auth-oauth-user",
+        "@octokit/request",
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/auth-oauth-device@7.1.1": {
+      "integrity": "sha512-HWl8lYueHonuyjrKKIup/1tiy0xcmQCdq5ikvMO1YwkNNkxb6DXfrPjrMYItNLyCP/o2H87WuijuE+SlBTT8eg==",
+      "dependencies": [
+        "@octokit/oauth-methods",
+        "@octokit/request",
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/auth-oauth-user@5.1.1": {
+      "integrity": "sha512-rRkMz0ErOppdvEfnemHJXgZ9vTPhBuC6yASeFaB7I2yLMd7QpjfrL1mnvRPlyKo+M6eeLxrKanXJ9Qte29SRsw==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/oauth-methods",
+        "@octokit/request",
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/auth-token@5.1.1": {
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA=="
+    },
+    "@octokit/auth-unauthenticated@6.1.0": {
+      "integrity": "sha512-zPSmfrUAcspZH/lOFQnVnvjQZsIvmfApQH6GzJrkIunDooU1Su2qt2FfMTSVPRp7WLTQyC20Kd55lF+mIYaohQ==",
+      "dependencies": [
+        "@octokit/request-error",
+        "@octokit/types"
+      ]
+    },
+    "@octokit/core@6.1.2": {
+      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+      "dependencies": [
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request",
+        "@octokit/request-error",
+        "@octokit/types",
+        "before-after-hook",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/endpoint@10.1.1": {
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "dependencies": [
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/graphql@8.1.1": {
+      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+      "dependencies": [
+        "@octokit/request",
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/oauth-app@7.1.3": {
+      "integrity": "sha512-EHXbOpBkSGVVGF1W+NLMmsnSsJRkcrnVmDKt0TQYRBb6xWfWzoi9sBD4DIqZ8jGhOWO/V8t4fqFyJ4vDQDn9bg==",
+      "dependencies": [
+        "@octokit/auth-oauth-app",
+        "@octokit/auth-oauth-user",
+        "@octokit/auth-unauthenticated",
+        "@octokit/core",
+        "@octokit/oauth-authorization-url",
+        "@octokit/oauth-methods",
+        "@types/aws-lambda",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/oauth-authorization-url@7.1.1": {
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
+    },
+    "@octokit/oauth-methods@5.1.2": {
+      "integrity": "sha512-C5lglRD+sBlbrhCUTxgJAFjWgJlmTx5bQ7Ch0+2uqRjYv7Cfb5xpX4WuSC9UgQna3sqRGBL9EImX9PvTpMaQ7g==",
+      "dependencies": [
+        "@octokit/oauth-authorization-url",
+        "@octokit/request",
+        "@octokit/request-error",
+        "@octokit/types"
+      ]
+    },
+    "@octokit/openapi-types@22.2.0": {
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+    },
+    "@octokit/openapi-webhooks-types@8.5.1": {
+      "integrity": "sha512-i3h1b5zpGSB39ffBbYdSGuAd0NhBAwPyA3QV3LYi/lx4lsbZiu7u2UHgXVUR6EpvOI8REOuVh1DZTRfHoJDvuQ=="
+    },
+    "@octokit/plugin-paginate-graphql@5.2.4_@octokit+core@6.1.2": {
+      "integrity": "sha512-pLZES1jWaOynXKHOqdnwZ5ULeVR6tVVCMm+AUbp0htdcyXDU95WbkYdU4R2ej1wKj5Tu94Mee2Ne0PjPO9cCyA==",
+      "dependencies": [
+        "@octokit/core"
+      ]
+    },
+    "@octokit/plugin-paginate-rest@11.3.6_@octokit+core@6.1.2": {
+      "integrity": "sha512-zcvqqf/+TicbTCa/Z+3w4eBJcAxCFymtc0UAIsR3dEVoNilWld4oXdscQ3laXamTszUZdusw97K8+DrbFiOwjw==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/types"
+      ]
+    },
+    "@octokit/plugin-rest-endpoint-methods@13.2.6_@octokit+core@6.1.2": {
+      "integrity": "sha512-wMsdyHMjSfKjGINkdGKki06VEkgdEldIGstIEyGX0wbYHGByOwN/KiM+hAAlUwAtPkP3gvXtVQA9L3ITdV2tVw==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/types"
+      ]
+    },
+    "@octokit/plugin-retry@7.1.2_@octokit+core@6.1.2": {
+      "integrity": "sha512-XOWnPpH2kJ5VTwozsxGurw+svB2e61aWlmk5EVIYZPwFK5F9h4cyPyj9CIKRyMXMHSwpIsI3mPOdpMmrRhe7UQ==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/request-error",
+        "@octokit/types",
+        "bottleneck"
+      ]
+    },
+    "@octokit/plugin-throttling@9.3.2_@octokit+core@6.1.2": {
+      "integrity": "sha512-FqpvcTpIWFpMMwIeSoypoJXysSAQ3R+ALJhXXSG1HTP3YZOIeLmcNcimKaXxTcws+Sh6yoRl13SJ5r8sXc1Fhw==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/types",
+        "bottleneck"
+      ]
+    },
+    "@octokit/request-error@6.1.5": {
+      "integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
+      "dependencies": [
+        "@octokit/types"
+      ]
+    },
+    "@octokit/request@9.1.3": {
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "dependencies": [
+        "@octokit/endpoint",
+        "@octokit/request-error",
+        "@octokit/types",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/types@13.6.2": {
+      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
+      "dependencies": [
+        "@octokit/openapi-types"
+      ]
+    },
+    "@octokit/webhooks-methods@5.1.0": {
+      "integrity": "sha512-yFZa3UH11VIxYnnoOYCVoJ3q4ChuSOk2IVBBQ0O3xtKX4x9bmKb/1t+Mxixv2iUhzMdOl1qeWJqEhouXXzB3rQ=="
+    },
+    "@octokit/webhooks@13.4.1": {
+      "integrity": "sha512-I5YPUtfWidh+OzyrlDahJsUpkpGK0kCTmDRbuqGmlCUzOtxdEkX3R4d6Cd08ijQYwkVXQJanPdbKuZBeV2NMaA==",
+      "dependencies": [
+        "@octokit/openapi-webhooks-types",
+        "@octokit/request-error",
+        "@octokit/webhooks-methods"
+      ]
+    },
+    "@types/aws-lambda@8.10.146": {
+      "integrity": "sha512-3BaDXYTh0e6UCJYL/jwV/3+GRslSc08toAiZSmleYtkAUyV5rtvdPYxrG/88uqvTuT6sb27WE9OS90ZNTIuQ0g=="
+    },
     "@types/node@22.5.4": {
       "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "dependencies": [
@@ -115,6 +316,12 @@
     },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "before-after-hook@3.0.2": {
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+    },
+    "bottleneck@2.19.5": {
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "commander@12.1.0": {
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
@@ -148,6 +355,21 @@
         "whatwg-url"
       ]
     },
+    "octokit@4.0.2_@octokit+core@6.1.2": {
+      "integrity": "sha512-wbqF4uc1YbcldtiBFfkSnquHtECEIpYD78YUXI6ri1Im5OO2NLo6ZVpRdbJpdnpZ05zMrVPssNiEo6JQtea+Qg==",
+      "dependencies": [
+        "@octokit/app",
+        "@octokit/core",
+        "@octokit/oauth-app",
+        "@octokit/plugin-paginate-graphql",
+        "@octokit/plugin-paginate-rest",
+        "@octokit/plugin-rest-endpoint-methods",
+        "@octokit/plugin-retry",
+        "@octokit/plugin-throttling",
+        "@octokit/request-error",
+        "@octokit/types"
+      ]
+    },
     "ofcoerce@0.7.0": {
       "integrity": "sha512-n0z5337OFJybuLhawRQuiSUgpQ+RdSJJ5XRfsAQ2q3OmjgS7chRfnIpR7TMnYbbGVoeBmtK9f2HLcM4ZMZOzew=="
     },
@@ -157,6 +379,9 @@
         "ansi-regex"
       ]
     },
+    "toad-cache@3.7.0": {
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
+    },
     "tr46@0.0.3": {
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
@@ -165,6 +390,12 @@
     },
     "unfetch@4.2.0": {
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
+    "universal-github-app-jwt@2.2.0": {
+      "integrity": "sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ=="
+    },
+    "universal-user-agent@7.0.2": {
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
     },
     "webidl-conversions@3.0.1": {
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
@@ -457,6 +688,7 @@
       "npm:@linear/sdk@33",
       "npm:commander@^12.1.0",
       "npm:enquirer@^2.4.1",
+      "npm:octokit@^4.0.2",
       "npm:zod@^3.23.8"
     ]
   }

--- a/src/github/fetcher.ts
+++ b/src/github/fetcher.ts
@@ -1,35 +1,29 @@
-import { load } from "../config.ts";
 import type { Task } from "../types/task.ts";
+import { load } from "../config.ts";
+import { Octokit } from "octokit";
 
 const config = await load();
-
-const apiUrl = "https://api.github.com";
 const token = config.providers.github.api.key;
 
-async function fetchGitHubIssue(issueId: string): Promise<any> {
-  const response = await fetch(
-    `${apiUrl}/repos/${config.providers.github.repo}/issues/${issueId}`,
-    {
-      headers: {
-        "Authorization": `token ${token}`,
-        "Accept": "application/vnd.github.v3+json",
-      },
-    },
-  );
+const octokit = new Octokit({ auth: token });
 
-  if (response.ok) {
-    return await response.json();
-  } else {
-    throw new Error(`Failed to fetch issue: ${response.status}`);
-  }
+async function fetchGitHubIssue(issueId: number) {
+  const [owner, repo] = config.providers.github.repo.split("/");
+  const { data } = await octokit.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueId,
+  });
+
+  return data;
 }
 
 async function githubFetcher(taskIds: string[]): Promise<Task[]> {
   return await Promise.all(taskIds.map(async (id) => {
-    const issue = await fetchGitHubIssue(id);
+    const issue = await fetchGitHubIssue(parseInt(id));
 
     return {
-      id: issue.id,
+      id: issue.id.toString(),
       identifier: id,
       title: issue.title,
       url: issue.html_url,

--- a/src/github/fetcher.ts
+++ b/src/github/fetcher.ts
@@ -1,0 +1,41 @@
+import { load } from "../config.ts";
+import type { Task } from "../types/task.ts";
+
+const config = await load();
+
+const apiUrl = "https://api.github.com";
+const token = config.providers.github.api.key;
+
+async function fetchGitHubIssue(issueId: string): Promise<any> {
+  const response = await fetch(
+    `${apiUrl}/repos/${config.providers.github.repo}/issues/${issueId}`,
+    {
+      headers: {
+        "Authorization": `token ${token}`,
+        "Accept": "application/vnd.github.v3+json",
+      },
+    },
+  );
+
+  if (response.ok) {
+    return await response.json();
+  } else {
+    throw new Error(`Failed to fetch issue: ${response.status}`);
+  }
+}
+
+async function githubFetcher(taskIds: string[]): Promise<Task[]> {
+  return await Promise.all(taskIds.map(async (id) => {
+    const issue = await fetchGitHubIssue(id);
+
+    return {
+      id: issue.id,
+      identifier: id,
+      title: issue.title,
+      url: issue.html_url,
+      message: issue.state ?? "Unknown",
+    };
+  }));
+}
+
+export { githubFetcher };

--- a/src/github/provider.ts
+++ b/src/github/provider.ts
@@ -1,0 +1,10 @@
+import { createProvider } from "../provider.ts";
+import { Provider } from "../types/provider.ts";
+import { githubFetcher } from "./fetcher.ts";
+
+const githubProvider = createProvider({
+  name: Provider.GitHub,
+  fetcher: githubFetcher,
+});
+
+export { githubProvider };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,6 @@
 import { jiraProvider } from "./jira/provider.ts";
 import { linearProvider } from "./linear/provider.ts";
+import { githubProvider } from "./github/provider.ts";
 import { Provider, type ProviderConfig } from "./types/provider.ts";
 
 /**
@@ -23,6 +24,8 @@ function getProvider({ name }: GetProviderParams) {
       return jiraProvider;
     case Provider.Linear:
       return linearProvider;
+    case Provider.GitHub:
+      return githubProvider;
     default:
       throw new Error(`Unsupported provider: ${name}`);
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,10 @@ type Config = {
       siteUrl: string;
       api: API;
     };
+    github: {
+      repo: string;
+      api: API;
+    };
   };
 };
 

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -3,6 +3,7 @@ import type { Task } from "./task.ts";
 enum Provider {
   Jira = "jira",
   Linear = "linear",
+  GitHub = "github",
 }
 
 type ProviderConfig = {

--- a/src/validation_test.ts
+++ b/src/validation_test.ts
@@ -18,7 +18,13 @@ Deno.test("validateProvider with invalid provider", () => {
   assertSpyCall(exitStub, 0, { args: [1] });
   assertSpyCall(consoleSpy, 0, {
     args: [
-      `Invalid provider "InvalidProvider". Please provide one of: jira, linear`,
+      `Invalid provider "InvalidProvider". Please provide one of: jira, linear, GitHub`,
     ],
   });
+});
+
+Deno.test("validateProvider with GitHub provider", () => {
+  const provider = Provider.GitHub;
+  const result = validateProvider(provider);
+  assertEquals(result, Provider.GitHub);
 });


### PR DESCRIPTION
Add GitHub issues as a new provider.

* **New files**: Add `src/github/fetcher.ts` to fetch GitHub issues using the GitHub API. Add `src/github/provider.ts` to define the GitHub provider.
* **Configuration**: Modify `src/types/config.ts` to include GitHub provider configuration.
* **Provider logic**: Modify `src/types/provider.ts` to add `GitHub` to the `Provider` enum. Modify `src/provider.ts` to import `githubProvider` and add a case for `Provider.GitHub` in the `getProvider` function.
* **Validation tests**: Modify `src/validation_test.ts` to add a test case for validating the GitHub provider.

